### PR TITLE
Add minimal Veeqo API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ accessed using the generic `request` method.
 from veeqo import VeeqoClient
 
 client = VeeqoClient(api_key="YOUR_API_KEY")
-products = client.list_products(limit=10)
+products = client.list_products(page=1)
 print(products)
+```
+
+You can also run the example script in ``examples/get_products.py``. Set the
+``VEEQO_API_KEY`` environment variable if you don't want to edit the file:
+
+```bash
+export VEEQO_API_KEY=YOUR_API_KEY
+python examples/get_products.py
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Veeqo-api
+# Veeqo API Client
+
+This repository provides a minimal Python client for the [Veeqo API](https://developers.veeqo.com/api).
+It exposes a `VeeqoClient` class that wraps HTTP requests and offers a few
+convenience methods for common endpoints. Unsupported endpoints can be
+accessed using the generic `request` method.
+
+## Example
+
+```python
+from veeqo import VeeqoClient
+
+client = VeeqoClient(api_key="YOUR_API_KEY")
+products = client.list_products(limit=10)
+print(products)
+```

--- a/examples/get_products.py
+++ b/examples/get_products.py
@@ -1,7 +1,7 @@
 from veeqo import VeeqoClient
 import os
 
-API_KEY = os.getenv("VEEQO_API_KEY", "Vqt/800967642dae577f3ed97a48ca8f9ff0")
+API_KEY = os.getenv("VEEQO_API_KEY", "****")
 
 client = VeeqoClient(api_key=API_KEY)
 products = client.list_products(page=1)

--- a/examples/get_products.py
+++ b/examples/get_products.py
@@ -1,0 +1,8 @@
+from veeqo import VeeqoClient
+import os
+
+API_KEY = os.getenv("VEEQO_API_KEY", "Vqt/800967642dae577f3ed97a48ca8f9ff0")
+
+client = VeeqoClient(api_key=API_KEY)
+products = client.list_products(page=1)
+print(products)

--- a/veeqo/__init__.py
+++ b/veeqo/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Python client for Veeqo API."""
+
+from .client import VeeqoClient
+
+__all__ = ["VeeqoClient"]

--- a/veeqo/client.py
+++ b/veeqo/client.py
@@ -1,0 +1,69 @@
+import requests
+from typing import Any, Dict, Optional
+
+
+class VeeqoClient:
+    """Minimal Veeqo API client.
+
+    This client provides generic request helpers and a few example
+    endpoint wrappers. The full Veeqo API includes many resources which
+    are not implemented here. For unsupported endpoints use the generic
+    ``request`` method.
+    """
+
+    def __init__(self, api_key: str, base_url: str = "https://api.veeqo.com") -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"})
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        """Make a request to the Veeqo API.
+
+        Parameters
+        ----------
+        method:
+            HTTP method (``'GET'``, ``'POST'``, etc).
+        path:
+            API path starting with ``/``.
+        params:
+            Query parameters for the request.
+        json:
+            JSON body to send with the request (for ``POST``/``PUT``/``PATCH``).
+        """
+        url = f"{self.base_url}{path}"
+        response = self.session.request(method, url, params=params, json=json)
+        response.raise_for_status()
+        return response
+
+    # Example convenience wrappers -----------------------------------------
+    def list_products(self, **params: Any) -> Dict[str, Any]:
+        """Return a list of products."""
+        resp = self.request("GET", "/products", params=params)
+        return resp.json()
+
+    def get_order(self, order_id: int) -> Dict[str, Any]:
+        """Retrieve a single order by ID."""
+        resp = self.request("GET", f"/orders/{order_id}")
+        return resp.json()
+
+    def create_order(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new order with the provided data."""
+        resp = self.request("POST", "/orders", json=data)
+        return resp.json()
+
+    def update_order(self, order_id: int, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an existing order."""
+        resp = self.request("PUT", f"/orders/{order_id}", json=data)
+        return resp.json()
+
+    def delete_order(self, order_id: int) -> None:
+        """Delete an order."""
+        self.request("DELETE", f"/orders/{order_id}")

--- a/veeqo/client.py
+++ b/veeqo/client.py
@@ -1,21 +1,27 @@
-import requests
+"""Minimal HTTP client for Veeqo API without external dependencies."""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Any, Dict, Optional
 
 
 class VeeqoClient:
     """Minimal Veeqo API client.
 
-    This client provides generic request helpers and a few example
-    endpoint wrappers. The full Veeqo API includes many resources which
-    are not implemented here. For unsupported endpoints use the generic
-    ``request`` method.
+    This implementation avoids third party dependencies so it can run in
+    restricted environments. Unsupported endpoints can be accessed using
+    the generic :py:meth:`request` method.
     """
 
     def __init__(self, api_key: str, base_url: str = "https://api.veeqo.com") -> None:
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
-        self.session = requests.Session()
-        self.session.headers.update({"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"})
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
 
     def request(
         self,
@@ -23,9 +29,9 @@ class VeeqoClient:
         path: str,
         *,
         params: Optional[Dict[str, Any]] = None,
-        json: Optional[Dict[str, Any]] = None,
-    ) -> requests.Response:
-        """Make a request to the Veeqo API.
+        json_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Make a request to the Veeqo API and return the parsed JSON response.
 
         Parameters
         ----------
@@ -39,30 +45,39 @@ class VeeqoClient:
             JSON body to send with the request (for ``POST``/``PUT``/``PATCH``).
         """
         url = f"{self.base_url}{path}"
-        response = self.session.request(method, url, params=params, json=json)
-        response.raise_for_status()
-        return response
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+
+        data = None
+        if json_data is not None:
+            data = json.dumps(json_data).encode()
+
+        req = urllib.request.Request(url, data=data, headers=self.headers, method=method)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as exc:
+            error_content = exc.read().decode()
+            raise RuntimeError(f"{exc.code} {exc.reason}: {error_content}") from exc
+
+        return json.loads(body)
 
     # Example convenience wrappers -----------------------------------------
     def list_products(self, **params: Any) -> Dict[str, Any]:
         """Return a list of products."""
-        resp = self.request("GET", "/products", params=params)
-        return resp.json()
+        return self.request("GET", "/products", params=params)
 
     def get_order(self, order_id: int) -> Dict[str, Any]:
         """Retrieve a single order by ID."""
-        resp = self.request("GET", f"/orders/{order_id}")
-        return resp.json()
+        return self.request("GET", f"/orders/{order_id}")
 
     def create_order(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new order with the provided data."""
-        resp = self.request("POST", "/orders", json=data)
-        return resp.json()
+        return self.request("POST", "/orders", json_data=data)
 
     def update_order(self, order_id: int, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing order."""
-        resp = self.request("PUT", f"/orders/{order_id}", json=data)
-        return resp.json()
+        return self.request("PUT", f"/orders/{order_id}", json_data=data)
 
     def delete_order(self, order_id: int) -> None:
         """Delete an order."""


### PR DESCRIPTION
## Summary
- add a `veeqo` package exposing a `VeeqoClient` class
- implement helper functions for generic requests and a few example endpoints
- update README with usage instructions

## Testing
- `python -m py_compile veeqo/__init__.py veeqo/client.py`


------
https://chatgpt.com/codex/tasks/task_e_684bd4eec01c833398b26d1a22103c07