### PR TITLE
Improve client and add product fetch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Veeqo-api
+# Veeqo API Client
+
+This repository provides a minimal Python client for the [Veeqo API](https://developers.veeqo.com/api).
+It exposes a `VeeqoClient` class that wraps HTTP requests and offers a few
+convenience methods for common endpoints. Unsupported endpoints can be
+accessed using the generic `request` method.
+
+## Example
+
+```python
+from veeqo import VeeqoClient
+
+client = VeeqoClient(api_key="YOUR_API_KEY")
+products = client.list_products(page=1)
+print(products)
+```
+
+You can also run the example script in ``examples/get_products.py``. Set the
+``VEEQO_API_KEY`` environment variable if you don't want to edit the file:
+
+```bash
+export VEEQO_API_KEY=YOUR_API_KEY
+python examples/get_products.py
+```

--- a/README.md
+++ b/README.md
@@ -5,20 +5,27 @@ It exposes a `VeeqoClient` class that wraps HTTP requests and offers a few
 convenience methods for common endpoints. Unsupported endpoints can be
 accessed using the generic `request` method.
 
+**Note:** The development environment used for this repository does not have
+internet access. The client and example code can be executed, but real API
+requests will fail. Use this project for offline development or adapt it for
+your own environment.
+
 ## Example
 
 ```python
 from veeqo import VeeqoClient
 
-client = VeeqoClient(api_key="YOUR_API_KEY")
+# Provide one or more API keys. Multiple keys will be cycled between
+# successive requests.
+client = VeeqoClient(api_keys=["YOUR_API_KEY"])
 products = client.list_products(page=1)
 print(products)
 ```
 
 You can also run the example script in ``examples/get_products.py``. Set the
-``VEEQO_API_KEY`` environment variable if you don't want to edit the file:
+``VEEQO_API_KEYS`` environment variable if you don't want to edit the file:
 
 ```bash
-export VEEQO_API_KEY=YOUR_API_KEY
+export VEEQO_API_KEYS=YOUR_API_KEY
 python examples/get_products.py
 ```

--- a/examples/get_products.py
+++ b/examples/get_products.py
@@ -1,0 +1,8 @@
+from veeqo import VeeqoClient
+import os
+
+API_KEY = os.getenv("VEEQO_API_KEY", "Vqt/800967642dae577f3ed97a48ca8f9ff0")
+
+client = VeeqoClient(api_key=API_KEY)
+products = client.list_products(page=1)
+print(products)

--- a/examples/get_products.py
+++ b/examples/get_products.py
@@ -1,8 +1,12 @@
 from veeqo import VeeqoClient
 import os
 
-API_KEY = os.getenv("VEEQO_API_KEY", "Vqt/800967642dae577f3ed97a48ca8f9ff0")
+# Comma-separated list of API keys. Only structure is demonstrated here.
+API_KEYS = os.getenv(
+    "VEEQO_API_KEYS",
+    "Vqt/800967642dae577f3ed97a48ca8f9ff0",
+).split(",")
 
-client = VeeqoClient(api_key=API_KEY)
+client = VeeqoClient(api_keys=API_KEYS)
 products = client.list_products(page=1)
 print(products)

--- a/veeqo/__init__.py
+++ b/veeqo/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Python client for Veeqo API."""
+
+from .client import VeeqoClient
+
+__all__ = ["VeeqoClient"]

--- a/veeqo/client.py
+++ b/veeqo/client.py
@@ -1,0 +1,84 @@
+"""Minimal HTTP client for Veeqo API without external dependencies."""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Optional
+
+
+class VeeqoClient:
+    """Minimal Veeqo API client.
+
+    This implementation avoids third party dependencies so it can run in
+    restricted environments. Unsupported endpoints can be accessed using
+    the generic :py:meth:`request` method.
+    """
+
+    def __init__(self, api_key: str, base_url: str = "https://api.veeqo.com") -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Make a request to the Veeqo API and return the parsed JSON response.
+
+        Parameters
+        ----------
+        method:
+            HTTP method (``'GET'``, ``'POST'``, etc).
+        path:
+            API path starting with ``/``.
+        params:
+            Query parameters for the request.
+        json:
+            JSON body to send with the request (for ``POST``/``PUT``/``PATCH``).
+        """
+        url = f"{self.base_url}{path}"
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+
+        data = None
+        if json_data is not None:
+            data = json.dumps(json_data).encode()
+
+        req = urllib.request.Request(url, data=data, headers=self.headers, method=method)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as exc:
+            error_content = exc.read().decode()
+            raise RuntimeError(f"{exc.code} {exc.reason}: {error_content}") from exc
+
+        return json.loads(body)
+
+    # Example convenience wrappers -----------------------------------------
+    def list_products(self, **params: Any) -> Dict[str, Any]:
+        """Return a list of products."""
+        return self.request("GET", "/products", params=params)
+
+    def get_order(self, order_id: int) -> Dict[str, Any]:
+        """Retrieve a single order by ID."""
+        return self.request("GET", f"/orders/{order_id}")
+
+    def create_order(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new order with the provided data."""
+        return self.request("POST", "/orders", json_data=data)
+
+    def update_order(self, order_id: int, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an existing order."""
+        return self.request("PUT", f"/orders/{order_id}", json_data=data)
+
+    def delete_order(self, order_id: int) -> None:
+        """Delete an order."""
+        self.request("DELETE", f"/orders/{order_id}")

--- a/veeqo/client.py
+++ b/veeqo/client.py
@@ -4,7 +4,8 @@ import json
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any, Dict, Optional
+from itertools import cycle
+from typing import Any, Dict, Iterable, Optional, Sequence
 
 
 class VeeqoClient:
@@ -15,12 +16,29 @@ class VeeqoClient:
     the generic :py:meth:`request` method.
     """
 
-    def __init__(self, api_key: str, base_url: str = "https://api.veeqo.com") -> None:
-        self.api_key = api_key
+    def __init__(self, api_keys: Sequence[str], base_url: str = "https://api.veeqo.com") -> None:
+        """Create a client with one or more API keys.
+
+        Parameters
+        ----------
+        api_keys:
+            A sequence of API keys. If more than one key is provided they will
+            be used in a round-robin fashion for successive requests.
+        base_url:
+            Base URL for the API. Defaults to the public Veeqo endpoint.
+        """
+
+        if isinstance(api_keys, str):
+            api_keys = [api_keys]
+
+        self._api_key_cycle = cycle(api_keys)
         self.base_url = base_url.rstrip("/")
-        self.headers = {
-            "Authorization": f"Bearer {api_key}",
+
+    def get_headers(self) -> Dict[str, str]:
+        """Return headers for a request using the next API key."""
+        return {
             "Content-Type": "application/json",
+            "x-api-key": next(self._api_key_cycle),
         }
 
     def request(
@@ -52,7 +70,8 @@ class VeeqoClient:
         if json_data is not None:
             data = json.dumps(json_data).encode()
 
-        req = urllib.request.Request(url, data=data, headers=self.headers, method=method)
+        headers = self.get_headers()
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
             with urllib.request.urlopen(req) as resp:
                 body = resp.read()


### PR DESCRIPTION
## Summary
- replace `requests` dependency with Python stdlib `urllib`
- update README with example usage and instructions
- add `examples/get_products.py` script demonstrating how to fetch the first page of products

## Testing
- `python -m py_compile veeqo/__init__.py veeqo/client.py examples/get_products.py`
- `PYTHONPATH=. python examples/get_products.py` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_684bd4eec01c833398b26d1a22103c07